### PR TITLE
Stop overriding .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       TWITTER_ACCESS_TOKEN:
       TWITTER_ACCESS_TOKEN_SECRET:
       # defaults to true, change to false if you don't want to enable it
-      TWITTER_CROSSPOSTING: true
-      MASTODON_CROSSPOSTING: true
+      TWITTER_CROSSPOSTING: ${TWITTER_CROSSPOSTING:-true}
+      MASTODON_CROSSPOSTING: ${MASTODON_CROSSPOSTING:-true}
       LOG_LEVEL:
       MASTODON_VISIBILITY:
       MENTIONS:
@@ -27,7 +27,7 @@ services:
       MAX_PER_HOUR:
       OVERFLOW_POST:
       # job interval, defaults to 1 hour(the max lag between bluesky and twitter/mastodon)
-      RUN_INTERVAL: 3600
+      RUN_INTERVAL: ${RUN_INTERVAL:-3600}
     volumes:
       - ./dbhost:/db
       - ./backup:/backup


### PR DESCRIPTION
When both env_file and environment are set for a service, values set by environment have precedence.

This means that currently TWITTER_CROSSPOSTING, MASTODON_CROSSPOSTING and RUN_INTERVAL cannot be overridden in the .env file.